### PR TITLE
Replace HomeGlow references

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HomeGlow - Premium Home Appliances</title>
+    <title>GIECOS SOLUTION - Premium Home Appliances</title>
     <meta name="description" content="Premium home appliances for modern living" />
-    <meta name="author" content="HomeGlow" />
+    <meta name="author" content="GIECOS SOLUTION" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
 
-    <meta property="og:title" content="HomeGlow - Premium Home Appliances" />
+    <meta property="og:title" content="GIECOS SOLUTION - Premium Home Appliances" />
     <meta property="og:description" content="Premium home appliances for modern living" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,7 +10,7 @@ const Footer: React.FC = () => {
           {/* Brand */}
           <div>
             <h3 className="text-xl font-playfair font-bold text-homeglow-accent mb-4">
-              HomeGlow
+              GIECOS SOLUTION
             </h3>
             <p className="text-gray-300">
               Premium home appliances for modern living. Quality you can trust.
@@ -51,7 +51,7 @@ const Footer: React.FC = () => {
         </div>
 
         <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-          <p>&copy; 2024 HomeGlow. All rights reserved.</p>
+          <p>&copy; 2024 GIECOS SOLUTION. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,7 +15,7 @@ const Header: React.FC = () => {
         <div className="flex items-center justify-between">
           {/* Logo */}
           <Link to="/" className="text-2xl font-playfair font-bold text-homeglow-primary">
-            HomeGlow
+            GIECOS SOLUTION
           </Link>
 
           {/* Navigation */}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -6,7 +6,7 @@ const About: React.FC = () => {
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-4xl font-playfair font-bold text-homeglow-primary mb-8 text-center">
-          About HomeGlow
+          About GIECOS SOLUTION
         </h1>
 
         <div className="prose prose-gray max-w-none">
@@ -15,7 +15,7 @@ const About: React.FC = () => {
               Our Story
             </h2>
             <p className="text-gray-600 leading-relaxed mb-4">
-              Founded in 2020, HomeGlow began as a simple idea: to bring premium home appliances 
+              Founded in 2020, GIECOS SOLUTION began as a simple idea: to bring premium home appliances
               to every household. We believe that quality appliances shouldn't be a luxury, but 
               an accessible way to enhance your daily life.
             </p>
@@ -26,7 +26,7 @@ const About: React.FC = () => {
               create the home of your dreams.
             </p>
             <p className="text-gray-600 leading-relaxed">
-              At HomeGlow, we're more than just a retailer – we're your partners in creating a 
+              At GIECOS SOLUTION, we're more than just a retailer – we're your partners in creating a
               home that truly glows with warmth, comfort, and modern convenience.
             </p>
           </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -67,7 +67,7 @@ const Home: React.FC = () => {
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-playfair font-bold text-homeglow-primary mb-4">
-              Why Choose HomeGlow?
+              Why Choose GIECOS SOLUTION?
             </h2>
             <p className="text-gray-600 max-w-2xl mx-auto">
               We're committed to providing exceptional service and premium products for your home

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,7 +16,7 @@ const Login: React.FC = () => {
     console.log('Login attempt:', formData);
     toast({
       title: "Login successful!",
-      description: "Welcome back to HomeGlow.",
+      description: "Welcome back to GIECOS SOLUTION.",
     });
   };
 
@@ -35,7 +35,7 @@ const Login: React.FC = () => {
             Welcome back
           </h2>
           <p className="mt-2 text-sm text-gray-600">
-            Sign in to your HomeGlow account
+            Sign in to your GIECOS SOLUTION account
           </p>
         </div>
         

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -32,7 +32,7 @@ const Signup: React.FC = () => {
       console.log('OTP verification:', otpValue);
       toast({
         title: "Account created successfully!",
-        description: "Welcome to HomeGlow.",
+          description: "Welcome to GIECOS SOLUTION.",
       });
     }
   };
@@ -53,7 +53,7 @@ const Signup: React.FC = () => {
           </h2>
           <p className="mt-2 text-sm text-gray-600">
             {step === 'signup' 
-              ? 'Join HomeGlow and start shopping' 
+              ? 'Join GIECOS SOLUTION and start shopping'
               : 'Enter the 6-digit code sent to your email'}
           </p>
         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -53,7 +54,7 @@ export default {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))'
 				},
-				// HomeGlow custom colors
+                                // GIECOS SOLUTION custom colors
 				'homeglow-bg': '#F8F5F2', // off-white background
 				'homeglow-primary': '#800020', // burgundy
 				'homeglow-accent': '#C73F40', // accent/hover
@@ -91,5 +92,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- update brand references across the UI
- fix lint errors from no-empty-interface and require imports

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862c2ebf5648323818e3fbcb0bf6fb3