### PR TITLE
Implement Fastify API with Prisma

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,9 @@
     "@prisma/client": "6.10.1",
     "fastify": "^5.4.0",
     "prisma": "^6.10.1",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "dotenv": "^16.4.5",
+    "fastify-plugin": "^5.0.1"
   },
   "devDependencies": {
     "@types/node": "^24.0.7",

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -20,9 +20,15 @@ importers:
       '@prisma/client':
         specifier: 6.10.1
         version: 6.10.1(prisma@6.10.1(typescript@5.8.3))(typescript@5.8.3)
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
       fastify:
         specifier: ^5.4.0
         version: 5.4.0
+      fastify-plugin:
+        specifier: ^5.0.1
+        version: 5.0.1
       prisma:
         specifier: ^6.10.1
         version: 6.10.1(typescript@5.8.3)
@@ -219,6 +225,10 @@ packages:
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dynamic-dedupe@0.3.0:
     resolution: {integrity: sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==}
@@ -753,6 +763,8 @@ snapshots:
   dequal@2.0.3: {}
 
   diff@4.0.2: {}
+
+  dotenv@16.6.1: {}
 
   dynamic-dedupe@0.3.0:
     dependencies:

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -1,0 +1,11 @@
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const { DATABASE_URL, JWT_SECRET, PORT } = process.env
+
+if (!DATABASE_URL) {
+  throw new Error('DATABASE_URL is required')
+}
+
+export { DATABASE_URL, JWT_SECRET, PORT }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,33 @@
+import Fastify from 'fastify'
+import cors from '@fastify/cors'
+import cookie from '@fastify/cookie'
+import jwt from '@fastify/jwt'
+
+import { PORT, JWT_SECRET } from './env'
+import prismaPlugin from './plugins/prisma'
+import productsRoutes from './routes/products'
+
+const app = Fastify({ logger: true })
+
+app.register(cors, {
+  origin: 'http://localhost:8080',
+  credentials: true,
+})
+app.register(cookie)
+if (JWT_SECRET) {
+  app.register(jwt, { secret: JWT_SECRET })
+}
+app.register(prismaPlugin)
+app.register(productsRoutes, { prefix: '/api/products' })
+
+const port = PORT ? parseInt(PORT, 10) : 4000
+
+app
+  .listen({ port, host: '0.0.0.0' })
+  .then(() => {
+    app.log.info(`Server listening on ${port}`)
+  })
+  .catch((err) => {
+    app.log.error(err)
+    process.exit(1)
+  })

--- a/api/src/plugins/prisma.ts
+++ b/api/src/plugins/prisma.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from '@prisma/client'
+import fp from 'fastify-plugin'
+import { FastifyPluginAsync } from 'fastify'
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    prisma: PrismaClient
+  }
+}
+
+const prismaPlugin: FastifyPluginAsync = async (fastify) => {
+  const prisma = new PrismaClient()
+  await prisma.$connect()
+  fastify.decorate('prisma', prisma)
+
+  fastify.addHook('onClose', async (app) => {
+    await app.prisma.$disconnect()
+  })
+}
+
+export default fp(prismaPlugin)

--- a/api/src/routes/products.ts
+++ b/api/src/routes/products.ts
@@ -1,0 +1,9 @@
+import { FastifyPluginAsync } from 'fastify'
+
+const productsRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/', async () => {
+    return fastify.prisma.product.findMany()
+  })
+}
+
+export default productsRoutes

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "dev:api": "pnpm --filter ./api ts-node-dev src/index.ts",
+    "dev:api": "pnpm --filter ./api exec ts-node-dev src/index.ts",
     "prisma": "pnpm --filter ./api prisma"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- set up environment loader for API
- add Prisma Fastify plugin
- implement product routes
- bootstrap Fastify server with common plugins
- add fastify-plugin and dotenv dependencies
- fix `dev:api` script

## Testing
- `pnpm --filter ./api exec prisma db push`
- `pnpm dev:api` *(started server)*
- `curl -s http://localhost:4000/api/products`