### PR TITLE
Add OrderStatus enum and migration

### DIFF
--- a/api/prisma/migrations/20250630210709_add_order_status/migration.sql
+++ b/api/prisma/migrations/20250630210709_add_order_status/migration.sql
@@ -1,0 +1,16 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Order" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    CONSTRAINT "Order_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Order" ("createdAt", "id", "updatedAt", "userId") SELECT "createdAt", "id", "updatedAt", "userId" FROM "Order";
+DROP TABLE "Order";
+ALTER TABLE "new_Order" RENAME TO "Order";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Order {
   userId    String
   createdAt DateTime    @default(now())
   updatedAt DateTime    @updatedAt
+  status    OrderStatus @default(PENDING)
   items     OrderItem[]
 }
 
@@ -46,4 +47,10 @@ model OrderItem {
   productId String
   quantity  Int
   price     Float
+}
+
+enum OrderStatus {
+  PENDING
+  PAID
+  SHIPPED
 }


### PR DESCRIPTION
## Summary
- add `OrderStatus` enum to Prisma schema
- store `status` on `Order` model
- run `pnpm prisma migrate dev --name add_order_status`

## Testing
- `npm run lint`